### PR TITLE
Linter fix

### DIFF
--- a/flake8.ini
+++ b/flake8.ini
@@ -1,0 +1,47 @@
+[flake8]
+
+# Plugins
+use-flake8-tabs = True
+# Not all checks are replaced by flake8-tabs, however, pycodestyle is still not compatible with tabs.
+use-pycodestyle-indent = False
+continuation-style = hanging
+## The following are replaced by flake8-tabs plugin, reported as ET codes rather than E codes.
+# E121, E122, E123, E126, E127, E128,
+## The following (all disabled) are not replaced by flake8-tabs,
+# E124 - Requires mixing spaces and tabs: Closing bracket does not match visual indentation.
+# E125 - Does not take tabs into consideration: Continuation line with same indent as next logical line.
+# E129 - Requires mixing spaces and tabs: Visually indented line with same indent as next logical line
+# E131 - Requires mixing spaces and tabs: Continuation line unaligned for hanging indent
+# E133 - Our preference handled by ET126: Closing bracket is missing indentation
+
+
+# Reporting
+statistics = True
+doctests = True
+show-source = True
+
+# Options
+max-complexity = 15
+max-line-length = 110
+# Final bracket should match indentation of the start of the line of the opening bracket
+hang-closing = False
+
+ignore =
+	W191,  # indentation contains tabs
+	W503,  # line break before binary operator. We want W504(line break after binary operator)
+	E117,  # These errors are reported incorrectly by VSCode lint interface
+
+
+builtins = # inform flake8 about functions we consider built-in.
+	_, # translation lookup
+	pgettext, # translation lookup
+
+exclude = # don't bother looking in the following subdirectories / files.
+	.git,
+	__pycache__,
+	.tox,
+	build,
+	output,
+	include,
+	miscDeps,
+	source/louis,

--- a/settings.json
+++ b/settings.json
@@ -1,31 +1,32 @@
 {
-    "editor.accessibilitySupport": "on",
-    "python.linting.enabled": true,
-    "python.linting.maxNumberOfProblems": 10000,
-    "python.linting.flake8Args": [
-        "--config=tests\\lint\\flake8.ini"
-    ],
-    "python.linting.flake8Enabled": true,
-    "python.linting.pylintEnabled": false,
-    "python.autoComplete.extraPaths": [
-        "source",
-        "include/comtypes",
-        "include/configobj/src",
-        "include/pyserial",
-        "include/wxPython",
-        "miscDeps/python"
-    ],	
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "editor.insertSpaces": false,
-    "python.testing.unittestArgs": [
-        "-v",
-        "-s",
-        "tests.unit",
-        "-p",
-        "test_*.py"
-    ],
-    "python.testing.pytestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
-    "python.testing.unittestEnabled": true
+	"editor.accessibilitySupport": "on",
+	"python.linting.enabled": true,
+	"python.linting.maxNumberOfProblems": 10000,
+	"python.linting.flake8Args": [
+		"--config", ".vscode/flake8.ini"
+	],
+	"python.linting.flake8Enabled": true,
+	"python.linting.pylintEnabled": false,
+	"python.autoComplete.extraPaths": [
+		"source",
+		"include/comtypes",
+		"include/configobj/src",
+		"include/pyserial",
+		"include/wxPython",
+		"miscDeps/python"
+	],	
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"editor.insertSpaces": false,
+	"python.testing.unittestArgs": [
+		"-v",
+		"-s",
+		"tests.unit",
+		"-p",
+		"test_*.py"
+	],
+	"python.testing.pytestEnabled": false,
+	"python.testing.nosetestsEnabled": false,
+	"python.testing.unittestEnabled": true,
+	"python.pythonPath": "C:\\Users\\Franci\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe"
 }


### PR DESCRIPTION
Hello,

Here are a quick fix for linting in Visual Studio Code linter extension. Additionally there are a formatting change in "settings.json" file.

The issue is that there are too many over-indented errors in the problems view when you open a file, caused by tab indentation.

Cheers,