### PR TITLE
Add CPP settings

### DIFF
--- a/c_cpp_properties.json
+++ b/c_cpp_properties.json
@@ -1,0 +1,21 @@
+{
+    "configurations": [
+        {
+            "name": "NVDAHelper",
+            "includePath": [
+                "${workspaceFolder}/include/**",
+                "${workspaceFolder}/miscdeps/include/**",
+                "${workspaceFolder}/nvdaHelper/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_CRT_SECURE_NO_DEPRECATE",
+                "_WIN32_WINNT=_WIN32_WINNT_WIN7"
+            ],
+            "intelliSenseMode": "msvc-x64",
+            "cppStandard": "c++17"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
This pr adds the cpp settings json file to the workspace. It ensures that, when working with NVDAHelper, the include path is limited to that in the archBuild_sconscript, thereby speeding up searching of includes. it also sets common defines.
I've also looked into support to build files from VS Code, but that's pretty non trivial.