### PR TITLE
Add definitions of built-in translation functions

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -10,7 +10,8 @@
     "python.autoComplete.extraPaths": [
         "source",
         "miscDeps/python"
-    ],	
+    ],
+    "python.analysis.stubPath": "${workspaceFolder}/.vscode/typings",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,

--- a/typings/__builtins__.pyi
+++ b/typings/__builtins__.pyi
@@ -1,0 +1,14 @@
+def _(msg: str) -> str:
+	...
+
+
+def pgettext(context: str, message: str) -> str:
+	...
+
+
+def ngettext(msgid1: str, msgid2: str, n: int) -> str:
+	...
+
+
+def npgettext(context: str, msgid1: str, msgid2: str, n: int) -> str:
+	...


### PR DESCRIPTION
NVDA installs several functions used for translations to the global built-in namespace. Since they're added into globals VS Code is not aware about them which results in warnings in the problems view. There is also no Intellisense for these functions. This Pr ads type stub with definitions of the translation functions, and ensures it is used by PyLance.