### PR TITLE
Add new python.analysis.extraPaths setting for Pylance

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -11,6 +11,10 @@
         "source",
         "miscDeps/python"
     ],
+    "python.analysis.extraPaths": [
+        "source",
+        "miscDeps/python"
+    ],
     "python.analysis.stubPath": "${workspaceFolder}/.vscode/typings",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,


### PR DESCRIPTION
When the default language server for the VS Code Python extension was switched from Microsoft Python Language Server to Pylance [some settings were renamed](https://github.com/microsoft/pylance-release/blob/main/MIGRATING_TO_PYLANCE.md). While this migration occurs automatically it causes VS Code config to be marked as dirty in Git. In this PR I have added a new setting `python.analysis.extraPaths` which is equivalent to the older `python.autoComplete.extraPaths`. Note that since it is possible to use a different (notably Jedi) language server for Python in VS Code, and I failed to find any conclusive documentation as to which setting it uses I've kept the old `python.autoComplete.extraPaths` setting as its presence causes no harm and may be needed for users of different language servers.