### PR TITLE
Small improvements: formatting, editorconfig

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -9,7 +9,8 @@
 		"cschlosser.doxdocgen",
 		"davidanson.vscode-markdownlint",
 		"ms-vscode.powershell",
-		"charliermarsh.ruff"
+		"charliermarsh.ruff",
+		"editorconfig.editorconfig"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/settings.json
+++ b/settings.json
@@ -24,5 +24,8 @@
     "autoDocstring.docstringFormat": "sphinx",
     "python.testing.pytestEnabled": false,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
 }


### PR DESCRIPTION
1. Add a suggestion for the editorconfig extension, see https://github.com/nvaccess/nvda/pull/16795
2. For Python, set ruff as default formatter