### PR TITLE
Suggest imports and make them relative

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -28,4 +28,6 @@
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
+    "python.analysis.autoImportCompletions": true,
+    "python.analysis.importFormat": "relative",
 }

--- a/settings.json
+++ b/settings.json
@@ -29,5 +29,5 @@
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "python.analysis.autoImportCompletions": true,
-    "python.analysis.importFormat": "relative",
+    "python.analysis.importFormat": "relative"
 }


### PR DESCRIPTION
Pylance can suggest imports, but it defaults to absolute imports by default. In NVDA's code base however, we prefer relative imports in packages.
This also enables pylances automatic import suggestions which is really helpful when coding.