### PR TITLE
Add autoDocstring to recommended extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -10,7 +10,8 @@
 		"davidanson.vscode-markdownlint",
 		"ms-vscode.powershell",
 		"charliermarsh.ruff",
-		"editorconfig.editorconfig"
+		"editorconfig.editorconfig",
+		"njpwerner.autodocstring",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/settings.json
+++ b/settings.json
@@ -21,7 +21,7 @@
         "-p",
         "test_*.py"
     ],
-    "autoDocstring.docstringFormat": "sphinx",
+    "autoDocstring.docstringFormat": "sphinx-notypes",
     "python.testing.pytestEnabled": false,
     "python.testing.nosetestsEnabled": false,
     "python.testing.unittestEnabled": true,


### PR DESCRIPTION
Closes #13
Added [autoDocstring - Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) to recommended extensions, and set it up to use [Sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html) without types per the [coding standards](https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/codingStandards.md).