### PR TITLE
Add Configuration for Remote Debugging

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -12,6 +12,8 @@
 		"charliermarsh.ruff",
 		"editorconfig.editorconfig",
 		"njpwerner.autodocstring",
+		"ms-python.debugpy",
+		"ms-vscode.remote-server",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/extensions.json
+++ b/extensions.json
@@ -14,6 +14,7 @@
 		"njpwerner.autodocstring",
 		"ms-python.debugpy",
 		"ms-vscode.remote-server",
+		"benjamin-simmonds.pythoncpp-debug",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,32 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "NVDA (Python)",
+			"type": "debugpy",
+			"request": "launch",
+			"program": "nvda.pyw",
+			"console": "internalConsole",
+			"cwd": "${workspaceFolder}/source",
+			"env": {
+				"VIRTUAL_ENV": "${workspaceFolder}/.venv",
+			},
+		},
+		{
+			"name": "C++ attach",
+			"type": "cppvsdbg",
+			"request": "attach",
+			"symbolOptions": {
+				"searchMicrosoftSymbolServer": true,
+			},
+			"processId": "",
+		},
+		{
+			"name": "NVDA (mixed)",
+			"type": "pythoncpp",
+			"request": "launch",
+			"pythonLaunchName": "NVDA (Python)",
+			"cppAttachName": "C++ attach",
+		}
+	]
+}


### PR DESCRIPTION
Added workspace configuration to enable remote debugging of NVDA.

- Added extensions: [Python Debugger](https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy), [Python C++ Debugger](https://marketplace.visualstudio.com/items?itemName=benjamin-simmonds.pythoncpp-debug), and [Remote - Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-server).
- Added configurations: NVDA (Python), C++ attach, and NVDA (mixed) (for debugging NVDA's Python and C++ simultaneously).

Related: nvaccess/nvda#16971