### PR TITLE
Add 64bit NVDA profiles

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -29,5 +29,22 @@
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "python.analysis.autoImportCompletions": true,
-    "python.analysis.importFormat": "relative"
+    "python.analysis.importFormat": "relative",
+    "terminal.integrated.profiles.windows": {
+        "PowerShell NVDA x64": {
+            "source": "PowerShell",
+            "env": {
+                "UV_PYTHON": "cpython-3.11.9-windows-x86_64-none"
+            },
+        },
+        "cmd NVDA x64": {
+            "path": [
+                "${env:windir}\\Sysnative\\cmd.exe",
+                "${env:windir}\\System32\\cmd.exe"
+            ],
+            "env": {
+                "UV_PYTHON": "cpython-3.11.9-windows-x86_64-none"
+            }
+        }
+    }
 }

--- a/settings.json
+++ b/settings.json
@@ -31,13 +31,13 @@
     "python.analysis.autoImportCompletions": true,
     "python.analysis.importFormat": "relative",
     "terminal.integrated.profiles.windows": {
-        "PowerShell NVDA x64": {
+        "64bit NVDA (PowerShell)": {
             "source": "PowerShell",
             "env": {
                 "UV_PYTHON": "cpython-3.11.9-windows-x86_64-none"
             },
         },
-        "cmd NVDA x64": {
+        "64bit NVDA (Command Prompt)": {
             "path": [
                 "${env:windir}\\Sysnative\\cmd.exe",
                 "${env:windir}\\System32\\cmd.exe"


### PR DESCRIPTION
Add PowerShell and Command Prompt profiles for building NVDA as a 64-bit application.
